### PR TITLE
Add public directory placeholder for Docker build

### DIFF
--- a/public/.gitkeep
+++ b/public/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep public directory tracked.


### PR DESCRIPTION
## Summary
- add a public directory with a tracked placeholder so the builder image always has /app/public

## Testing
- `docker build .` *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d854fb5790833096dba6313af8acc5