### PR TITLE
Add cloud disk metadata management for reports

### DIFF
--- a/src/app/api/checks/[id]/route.ts
+++ b/src/app/api/checks/[id]/route.ts
@@ -9,6 +9,7 @@ export async function GET(
   if (!check) {
     return NextResponse.json({ message: 'Проверка не найдена' }, { status: 404 });
   }
+  const report = check.report;
   return NextResponse.json({
     check: {
       id: check.id,
@@ -18,6 +19,9 @@ export async function GET(
       createdAt: check.created_at,
       completedAt: check.completed_at,
       reportId: check.report_id,
+      reportName: report?.original_name ?? null,
+      reportCloudLink: report?.cloud_link ?? null,
+      reportAddedToCloud: report ? Boolean(report.added_to_cloud) : false,
     },
   });
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -328,6 +328,36 @@ a {
   color: var(--color-slate-500);
 }
 
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.form-field__label {
+  font-weight: 600;
+  color: var(--color-slate-700);
+}
+
+.form-field__input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.form-field__input:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.form-field__hint {
+  font-size: 0.8rem;
+  color: var(--color-slate-500);
+}
+
 .form-footer {
   display: flex;
   align-items: center;
@@ -388,6 +418,33 @@ a {
   background: rgba(37, 99, 235, 0.06);
 }
 
+.cloud-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  align-items: flex-start;
+}
+
+.cloud-cell__link {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.cloud-cell__link:hover {
+  text-decoration: underline;
+}
+
+.cloud-cell__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.cloud-cell__action {
+  padding: 0.35rem 0.8rem;
+}
+
 .status-chip {
   display: inline-flex;
   align-items: center;
@@ -430,6 +487,50 @@ a {
   color: var(--color-slate-500);
   background: rgba(148, 163, 184, 0.14);
   border-color: rgba(148, 163, 184, 0.24);
+}
+
+.cloud-panel {
+  margin-top: 1.4rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: 1rem;
+  background: rgba(37, 99, 235, 0.06);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.cloud-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.cloud-panel__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.cloud-panel__description {
+  margin: 0;
+  color: var(--color-slate-700);
+  line-height: 1.5;
+}
+
+.cloud-panel__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cloud-panel__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-slate-500);
 }
 
 .results-grid {

--- a/src/lib/check-processor.ts
+++ b/src/lib/check-processor.ts
@@ -114,5 +114,6 @@ export function getCheckResult(checkId: string) {
     return undefined;
   }
   const matches: MatchResult[] = check.matches ? JSON.parse(check.matches) : [];
-  return { ...check, matches };
+  const report = getReportById(check.report_id);
+  return { ...check, matches, report };
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,7 +10,9 @@ db.exec(`
     original_name TEXT NOT NULL,
     stored_name TEXT NOT NULL,
     text_content TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    cloud_link TEXT,
+    added_to_cloud INTEGER NOT NULL DEFAULT 0
   );
 
   CREATE TABLE IF NOT EXISTS checks (
@@ -24,5 +26,17 @@ db.exec(`
     FOREIGN KEY(report_id) REFERENCES reports(id)
   );
 `);
+
+type TableColumn = { name: string };
+
+const reportColumns = db.prepare(`PRAGMA table_info(reports)`).all() as TableColumn[];
+
+if (!reportColumns.some((column) => column.name === 'cloud_link')) {
+  db.prepare(`ALTER TABLE reports ADD COLUMN cloud_link TEXT`).run();
+}
+
+if (!reportColumns.some((column) => column.name === 'added_to_cloud')) {
+  db.prepare(`ALTER TABLE reports ADD COLUMN added_to_cloud INTEGER NOT NULL DEFAULT 0`).run();
+}
 
 export default db;

--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -6,6 +6,8 @@ export interface ReportRecord {
   original_name: string;
   stored_name: string;
   text_content: string;
+  cloud_link: string | null;
+  added_to_cloud: 0 | 1;
   created_at: string;
 }
 
@@ -19,17 +21,31 @@ export interface CheckRecord {
   completed_at: string | null;
 }
 
-export function createReport(record: Omit<ReportRecord, 'id' | 'created_at'> & { id?: string }): ReportRecord {
+export interface CreateReportInput {
+  id?: string;
+  original_name: string;
+  stored_name: string;
+  text_content: string;
+  cloud_link?: string | null;
+  added_to_cloud?: boolean;
+}
+
+export function createReport(record: CreateReportInput): ReportRecord {
   const id = record.id ?? randomUUID();
   const created_at = new Date().toISOString();
+  const cloud_link = record.cloud_link ?? null;
+  const added_to_cloud = record.added_to_cloud ? 1 : 0;
   db.prepare(
-    `INSERT INTO reports (id, original_name, stored_name, text_content, created_at) VALUES (?, ?, ?, ?, ?)`
-  ).run(id, record.original_name, record.stored_name, record.text_content, created_at);
+    `INSERT INTO reports (id, original_name, stored_name, text_content, created_at, cloud_link, added_to_cloud)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, record.original_name, record.stored_name, record.text_content, created_at, cloud_link, added_to_cloud);
   return {
     id,
     original_name: record.original_name,
     stored_name: record.stored_name,
     text_content: record.text_content,
+    cloud_link,
+    added_to_cloud,
     created_at,
   };
 }
@@ -40,6 +56,52 @@ export function listReports(): ReportRecord[] {
 
 export function getReportById(id: string): ReportRecord | undefined {
   return db.prepare(`SELECT * FROM reports WHERE id = ?`).get(id) as ReportRecord | undefined;
+}
+
+export interface UpdateReportInput {
+  original_name?: string;
+  stored_name?: string;
+  text_content?: string;
+  cloud_link?: string | null;
+  added_to_cloud?: boolean;
+}
+
+export function updateReport(id: string, updates: UpdateReportInput): ReportRecord | undefined {
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (updates.original_name !== undefined) {
+    fields.push('original_name = ?');
+    values.push(updates.original_name);
+  }
+
+  if (updates.stored_name !== undefined) {
+    fields.push('stored_name = ?');
+    values.push(updates.stored_name);
+  }
+
+  if (updates.text_content !== undefined) {
+    fields.push('text_content = ?');
+    values.push(updates.text_content);
+  }
+
+  if (updates.cloud_link !== undefined) {
+    fields.push('cloud_link = ?');
+    values.push(updates.cloud_link);
+  }
+
+  if (updates.added_to_cloud !== undefined) {
+    fields.push('added_to_cloud = ?');
+    values.push(updates.added_to_cloud ? 1 : 0);
+  }
+
+  if (!fields.length) {
+    return getReportById(id);
+  }
+
+  values.push(id);
+  db.prepare(`UPDATE reports SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+  return getReportById(id);
 }
 
 export function createCheck(record: Omit<CheckRecord, 'id' | 'created_at' | 'completed_at'> & { id?: string; created_at?: string; completed_at?: string | null }): CheckRecord {


### PR DESCRIPTION
## Summary
- add cloud storage link metadata and uploaded flag to report persistence and APIs
- expose the cloud link alongside report checks, with endpoints to update or mark reports as uploaded
- extend the UI with inputs and controls to manage cloud disk links and trigger the upload workflow after checks complete

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d85c0984008330a49f39eeecdd7104