### PR TITLE
Add mocked tests for report upload handler

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/storage', () => ({
+  persistReportFile: vi.fn(),
+}));
+
+vi.mock('@/lib/repository', () => ({
+  createReport: vi.fn(),
+  listReports: vi.fn(),
+  findLatestCheckForReport: vi.fn(),
+}));
+
+vi.mock('@/lib/check-processor', () => ({
+  queueCheck: vi.fn(),
+}));
+
+vi.mock('pdf-parse', () => ({
+  default: vi.fn(),
+}));
+
+import { POST } from './route';
+import { persistReportFile } from '@/lib/storage';
+import { createReport } from '@/lib/repository';
+import { queueCheck } from '@/lib/check-processor';
+import pdfParse from 'pdf-parse';
+
+const persistReportFileMock = vi.mocked(persistReportFile);
+const createReportMock = vi.mocked(createReport);
+const queueCheckMock = vi.mocked(queueCheck);
+const pdfParseMock = vi.mocked(pdfParse);
+
+describe('POST /api/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves uploaded report and queues a check', async () => {
+    const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const formData = new FormData();
+    formData.set('file', file);
+    formData.set('cloudLink', 'https://example.com/report');
+
+    const storedReport = {
+      id: 'report-123',
+      storedName: 'report-123.pdf',
+      absolutePath: '/tmp/report-123.pdf',
+    };
+    persistReportFileMock.mockReturnValue(storedReport);
+
+    createReportMock.mockReturnValue({
+      id: storedReport.id,
+      original_name: file.name,
+      stored_name: storedReport.storedName,
+      text_content: 'parsed text',
+      cloud_link: 'https://example.com/report',
+      added_to_cloud: 0,
+      created_at: '2024-01-01T00:00:00.000Z',
+    });
+
+    queueCheckMock.mockReturnValue({
+      id: 'check-456',
+      report_id: storedReport.id,
+      status: 'queued',
+      similarity: null,
+      matches: '[]',
+      created_at: '2024-01-01T00:01:00.000Z',
+      completed_at: null,
+    });
+
+    pdfParseMock.mockResolvedValue({
+      text: 'parsed text',
+    });
+
+    const request = {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      reportId: storedReport.id,
+      checkId: 'check-456',
+      status: 'queued',
+    });
+
+    expect(persistReportFileMock).toHaveBeenCalledTimes(1);
+    expect(persistReportFileMock.mock.calls[0][0]).toBeInstanceOf(Buffer);
+    expect(persistReportFileMock.mock.calls[0][1]).toBe('report.pdf');
+
+    expect(createReportMock).toHaveBeenCalledWith({
+      id: storedReport.id,
+      original_name: 'report.pdf',
+      stored_name: storedReport.storedName,
+      text_content: 'parsed text',
+      cloud_link: 'https://example.com/report',
+    });
+
+    expect(queueCheckMock).toHaveBeenCalledWith(storedReport.id);
+  });
+
+  it('returns 400 when cloud link is invalid', async () => {
+    const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const formData = new FormData();
+    formData.set('file', file);
+    formData.set('cloudLink', 'not-a-valid-url');
+
+    const request = {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Некорректная ссылка на облачный диск',
+    });
+
+    expect(pdfParseMock).not.toHaveBeenCalled();
+    expect(persistReportFileMock).not.toHaveBeenCalled();
+    expect(createReportMock).not.toHaveBeenCalled();
+    expect(queueCheckMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest suite for the report upload route using mocks of storage, repository, and pdf parsing
- verify successful uploads trigger persistence, report creation, and check queueing
- cover validation that rejects invalid cloud links before any storage calls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d85f5e100883309c2bb59075bc99b8