### PR TITLE
Add multi-file cloud-first upload flow

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -110,6 +110,93 @@ describe('POST /api/reports', () => {
     expect(queueCheckMock).toHaveBeenCalledWith(storedReport.id);
   });
 
+  it('supports uploading multiple PDF files at once', async () => {
+    const files = [
+      new File(['%PDF-1.7 test content'], 'first.pdf', { type: 'application/pdf' }),
+      new File(['%PDF-1.7 test content 2'], 'second.pdf', { type: 'application/pdf' }),
+    ];
+    const formData = new FormData();
+    files.forEach((file) => formData.append('files', file));
+    formData.set('cloudLink', 'https://example.com/report');
+
+    persistReportFileMock
+      .mockReturnValueOnce({
+        id: 'report-1',
+        storedName: 'report-1.pdf',
+        absolutePath: '/tmp/report-1.pdf',
+      })
+      .mockReturnValueOnce({
+        id: 'report-2',
+        storedName: 'report-2.pdf',
+        absolutePath: '/tmp/report-2.pdf',
+      });
+
+    persistReportTextMock
+      .mockReturnValueOnce({ index: 'report-1.txt', absolutePath: '/tmp/report-1.txt' })
+      .mockReturnValueOnce({ index: 'report-2.txt', absolutePath: '/tmp/report-2.txt' });
+
+    createReportMock
+      .mockReturnValueOnce({
+        id: 'report-1',
+        original_name: 'first.pdf',
+        stored_name: 'report-1.pdf',
+        text_index: 'report-1.txt',
+        cloud_link: 'https://example.com/report',
+        added_to_cloud: 0,
+        created_at: '2024-01-01T00:00:00.000Z',
+      })
+      .mockReturnValueOnce({
+        id: 'report-2',
+        original_name: 'second.pdf',
+        stored_name: 'report-2.pdf',
+        text_index: 'report-2.txt',
+        cloud_link: 'https://example.com/report',
+        added_to_cloud: 0,
+        created_at: '2024-01-01T00:00:10.000Z',
+      });
+
+    queueCheckMock
+      .mockReturnValueOnce({
+        id: 'check-1',
+        report_id: 'report-1',
+        status: 'queued',
+        similarity: null,
+        matches: '[]',
+        created_at: '2024-01-01T00:01:00.000Z',
+        completed_at: null,
+      })
+      .mockReturnValueOnce({
+        id: 'check-2',
+        report_id: 'report-2',
+        status: 'queued',
+        similarity: null,
+        matches: '[]',
+        created_at: '2024-01-01T00:01:10.000Z',
+        completed_at: null,
+      });
+
+    pdfParseMock.mockResolvedValue({ text: 'parsed text' });
+
+    const request = {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        { reportId: 'report-1', checkId: 'check-1', status: 'queued' },
+        { reportId: 'report-2', checkId: 'check-2', status: 'queued' },
+      ],
+    });
+
+    expect(persistReportFileMock).toHaveBeenCalledTimes(2);
+    expect(persistReportTextMock).toHaveBeenNthCalledWith(1, 'report-1', 'parsed text');
+    expect(persistReportTextMock).toHaveBeenNthCalledWith(2, 'report-2', 'parsed text');
+    expect(queueCheckMock).toHaveBeenCalledTimes(2);
+  });
+
   it('returns 400 when cloud link is invalid', async () => {
     const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
       type: 'application/pdf',
@@ -133,5 +220,27 @@ describe('POST /api/reports', () => {
     expect(persistReportFileMock).not.toHaveBeenCalled();
     expect(createReportMock).not.toHaveBeenCalled();
     expect(queueCheckMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when cloud link is missing', async () => {
+    const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const formData = new FormData();
+    formData.set('file', file);
+
+    const request = {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Ссылка на облачное хранилище обязательна',
+    });
+
+    expect(pdfParseMock).not.toHaveBeenCalled();
+    expect(persistReportFileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
   --color-slate-950: #020617;
   --color-slate-900: #0f172a;
   --color-slate-700: #334155;
+  --color-slate-600: #475569;
   --color-slate-500: #64748b;
   --color-slate-300: #cbd5f5;
   --color-slate-200: #e2e8f0;
@@ -271,6 +272,70 @@ a {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+}
+
+.upload-steps {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.upload-step {
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: 1rem;
+  padding: 1.4rem;
+  background: rgba(37, 99, 235, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.upload-step__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.upload-step__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 4.5rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.6rem;
+}
+
+.upload-step__title {
+  margin: 0 0 0.45rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.upload-step__description {
+  margin: 0;
+  color: var(--color-slate-600);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.upload-step__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.upload-step__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
 }
 
 .dropzone {


### PR DESCRIPTION
## Summary
- require users to confirm a cloud storage link before uploading new reports and support multi-file uploads in the interface
- style the upload form with step cards that guide users through connecting cloud storage and submitting PDFs
- update the report upload API to require a cloud link, accept multiple PDFs, and extend tests to cover the new flow

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d87916e0dc8330bd3f246b2f085fee