### PR TITLE
Sync cloud storage before report upload

### DIFF
--- a/src/lib/repository.ts
+++ b/src/lib/repository.ts
@@ -168,3 +168,14 @@ export function findLatestCheckForReport(reportId: string): CheckRecord | undefi
     .prepare(`SELECT * FROM checks WHERE report_id = ? ORDER BY datetime(created_at) DESC LIMIT 1`)
     .get(reportId) as CheckRecord | undefined;
 }
+
+export function findReportByCloudLinkAndName(
+  cloudLink: string,
+  originalName: string
+): ReportRecord | undefined {
+  return db
+    .prepare(
+      `SELECT * FROM reports WHERE cloud_link = ? AND original_name = ? ORDER BY datetime(created_at) DESC LIMIT 1`
+    )
+    .get(cloudLink, originalName) as ReportRecord | undefined;
+}


### PR DESCRIPTION
## Summary
- add a cloud storage synchronisation step that imports PDF references from the provided link before queuing checks
- handle validation and network failures from cloud sync with clear API responses
- cover the new behaviour with unit tests and repository helper for locating existing cloud entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d881d2d78c83308bab611449549ab2