### PR TITLE
Validate cloud links and preview scanned resources

### DIFF
--- a/src/app/api/cloud/scan/route.test.ts
+++ b/src/app/api/cloud/scan/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+vi.mock('@/lib/cloud-scanner', () => ({
+  inspectCloudStorage: vi.fn(),
+  CloudSyncError: class MockCloudSyncError extends Error {},
+}));
+
+import { POST } from './route';
+import { inspectCloudStorage, CloudSyncError } from '@/lib/cloud-scanner';
+
+const inspectCloudStorageMock = vi.mocked(inspectCloudStorage);
+
+describe('POST /api/cloud/scan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns preview when scan succeeds', async () => {
+    inspectCloudStorageMock.mockResolvedValue([
+      { name: 'first.pdf', status: 'new' },
+      { name: 'second.pdf', status: 'existing' },
+    ]);
+
+    const request = {
+      json: vi.fn().mockResolvedValue({ cloudLink: 'https://disk.yandex.ru/d/folder' }),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      cloudLink: 'https://disk.yandex.ru/d/folder',
+      resources: [
+        { name: 'first.pdf', status: 'new' },
+        { name: 'second.pdf', status: 'existing' },
+      ],
+    });
+    expect(inspectCloudStorageMock).toHaveBeenCalledWith('https://disk.yandex.ru/d/folder');
+  });
+
+  it('returns 400 when request body is missing', async () => {
+    const request = {
+      json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Ссылка на облачный диск обязательна',
+    });
+    expect(inspectCloudStorageMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when cloud link host is not supported', async () => {
+    const request = {
+      json: vi.fn().mockResolvedValue({ cloudLink: 'https://example.com/folder' }),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Ссылка должна вести на поддерживаемое облачное хранилище',
+    });
+    expect(inspectCloudStorageMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when cloud scanner reports a validation error', async () => {
+    inspectCloudStorageMock.mockRejectedValueOnce(new CloudSyncError('Validation error'));
+
+    const request = {
+      json: vi.fn().mockResolvedValue({ cloudLink: 'https://disk.yandex.ru/d/folder' }),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ message: 'Validation error' });
+  });
+
+  it('returns 502 when unexpected error occurs', async () => {
+    inspectCloudStorageMock.mockRejectedValueOnce(new Error('network down'));
+
+    const request = {
+      json: vi.fn().mockResolvedValue({ cloudLink: 'https://disk.yandex.ru/d/folder' }),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Не удалось просканировать облачное хранилище',
+    });
+  });
+});

--- a/src/app/api/cloud/scan/route.ts
+++ b/src/app/api/cloud/scan/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CloudLinkValidationError, normalizeCloudLink } from '@/lib/cloud-link';
+import { CloudSyncError, inspectCloudStorage } from '@/lib/cloud-scanner';
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ message: 'Ссылка на облачный диск обязательна' }, { status: 400 });
+  }
+
+  const cloudLinkRaw = (body as { cloudLink?: unknown })?.cloudLink;
+  if (typeof cloudLinkRaw !== 'string') {
+    return NextResponse.json({ message: 'Ссылка на облачный диск обязательна' }, { status: 400 });
+  }
+
+  let cloudLink: string;
+  try {
+    cloudLink = normalizeCloudLink(cloudLinkRaw);
+  } catch (error) {
+    if (error instanceof CloudLinkValidationError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+
+  try {
+    const resources = await inspectCloudStorage(cloudLink);
+    return NextResponse.json({ cloudLink, resources });
+  } catch (error) {
+    if (error instanceof CloudSyncError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    console.error('Cloud inspection failed', error);
+    return NextResponse.json({ message: 'Не удалось просканировать облачное хранилище' }, { status: 502 });
+  }
+}

--- a/src/app/api/reports/[id]/route.test.ts
+++ b/src/app/api/reports/[id]/route.test.ts
@@ -32,19 +32,19 @@ describe('PATCH /api/reports/[id]', () => {
 
   it('automatically marks report as added to cloud when link is provided', async () => {
     const request = {
-      json: vi.fn().mockResolvedValue({ cloudLink: 'https://example.com/folder' }),
+      json: vi.fn().mockResolvedValue({ cloudLink: 'https://disk.yandex.ru/d/folder' }),
     } as unknown as NextRequest;
 
     updateReportMock.mockReturnValue({
       ...baseReport,
-      cloud_link: 'https://example.com/folder',
+      cloud_link: 'https://disk.yandex.ru/d/folder',
       added_to_cloud: 1,
     });
 
     const response = await PATCH(request, { params: { id: baseReport.id } });
 
     expect(updateReportMock).toHaveBeenCalledWith(baseReport.id, {
-      cloud_link: 'https://example.com/folder',
+      cloud_link: 'https://disk.yandex.ru/d/folder',
       added_to_cloud: true,
     });
 
@@ -54,7 +54,7 @@ describe('PATCH /api/reports/[id]', () => {
         id: baseReport.id,
         originalName: baseReport.original_name,
         createdAt: baseReport.created_at,
-        cloudLink: 'https://example.com/folder',
+        cloudLink: 'https://disk.yandex.ru/d/folder',
         addedToCloud: true,
       },
     });
@@ -63,7 +63,7 @@ describe('PATCH /api/reports/[id]', () => {
   it('unmarks report when cloud link is cleared', async () => {
     getReportByIdMock.mockReturnValueOnce({
       ...baseReport,
-      cloud_link: 'https://example.com/folder',
+      cloud_link: 'https://disk.yandex.ru/d/folder',
       added_to_cloud: 1,
     });
 

--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -51,7 +51,7 @@ describe('POST /api/reports', () => {
     });
     const formData = new FormData();
     formData.set('file', file);
-    formData.set('cloudLink', 'https://example.com/report');
+    formData.set('cloudLink', 'https://disk.yandex.ru/d/report');
 
     const storedReport = {
       id: 'report-123',
@@ -69,7 +69,7 @@ describe('POST /api/reports', () => {
       original_name: file.name,
       stored_name: storedReport.storedName,
       text_index: 'report-123.txt',
-      cloud_link: 'https://example.com/report',
+      cloud_link: 'https://disk.yandex.ru/d/report',
       added_to_cloud: 0,
       created_at: '2024-01-01T00:00:00.000Z',
     });
@@ -112,11 +112,11 @@ describe('POST /api/reports', () => {
       original_name: 'report.pdf',
       stored_name: storedReport.storedName,
       text_index: 'report-123.txt',
-      cloud_link: 'https://example.com/report',
+      cloud_link: 'https://disk.yandex.ru/d/report',
     });
 
     expect(queueCheckMock).toHaveBeenCalledWith(storedReport.id);
-    expect(syncCloudStorageMock).toHaveBeenCalledWith('https://example.com/report');
+    expect(syncCloudStorageMock).toHaveBeenCalledWith('https://disk.yandex.ru/d/report');
   });
 
   it('supports uploading multiple PDF files at once', async () => {
@@ -126,7 +126,7 @@ describe('POST /api/reports', () => {
     ];
     const formData = new FormData();
     files.forEach((file) => formData.append('files', file));
-    formData.set('cloudLink', 'https://example.com/report');
+    formData.set('cloudLink', 'https://disk.yandex.ru/d/report');
 
     persistReportFileMock
       .mockReturnValueOnce({
@@ -150,7 +150,7 @@ describe('POST /api/reports', () => {
         original_name: 'first.pdf',
         stored_name: 'report-1.pdf',
         text_index: 'report-1.txt',
-        cloud_link: 'https://example.com/report',
+        cloud_link: 'https://disk.yandex.ru/d/report',
         added_to_cloud: 0,
         created_at: '2024-01-01T00:00:00.000Z',
       })
@@ -159,7 +159,7 @@ describe('POST /api/reports', () => {
         original_name: 'second.pdf',
         stored_name: 'report-2.pdf',
         text_index: 'report-2.txt',
-        cloud_link: 'https://example.com/report',
+        cloud_link: 'https://disk.yandex.ru/d/report',
         added_to_cloud: 0,
         created_at: '2024-01-01T00:00:10.000Z',
       });
@@ -231,6 +231,31 @@ describe('POST /api/reports', () => {
     expect(queueCheckMock).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when cloud host is unsupported', async () => {
+    const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
+      type: 'application/pdf',
+    });
+    const formData = new FormData();
+    formData.set('file', file);
+    formData.set('cloudLink', 'https://example.com/report');
+
+    const request = {
+      formData: vi.fn().mockResolvedValue(formData),
+    } as unknown as NextRequest;
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Ссылка должна вести на поддерживаемое облачное хранилище',
+    });
+
+    expect(pdfParseMock).not.toHaveBeenCalled();
+    expect(persistReportFileMock).not.toHaveBeenCalled();
+    expect(createReportMock).not.toHaveBeenCalled();
+    expect(queueCheckMock).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when cloud link is missing', async () => {
     const file = new File(['%PDF-1.7 test content'], 'report.pdf', {
       type: 'application/pdf',
@@ -259,7 +284,7 @@ describe('POST /api/reports', () => {
     });
     const formData = new FormData();
     formData.set('file', file);
-    formData.set('cloudLink', 'https://example.com/folder');
+    formData.set('cloudLink', 'https://disk.yandex.ru/d/folder');
 
     pdfParseMock.mockRejectedValue(new Error('Invalid PDF structure.'));
 
@@ -286,7 +311,7 @@ describe('POST /api/reports', () => {
     });
     const formData = new FormData();
     formData.set('file', file);
-    formData.set('cloudLink', 'https://example.com/report');
+    formData.set('cloudLink', 'https://disk.yandex.ru/d/report');
 
     syncCloudStorageMock.mockRejectedValueOnce(new CloudSyncError('Cloud validation error'));
 
@@ -307,7 +332,7 @@ describe('POST /api/reports', () => {
     });
     const formData = new FormData();
     formData.set('file', file);
-    formData.set('cloudLink', 'https://example.com/report');
+    formData.set('cloudLink', 'https://disk.yandex.ru/d/report');
 
     syncCloudStorageMock.mockRejectedValueOnce(new Error('network down'));
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --color-slate-950: #020617;
   --color-slate-900: #0f172a;
+  --color-slate-800: #1e293b;
   --color-slate-700: #334155;
   --color-slate-600: #475569;
   --color-slate-500: #64748b;
@@ -508,6 +509,107 @@ a {
 
 .cloud-cell__action {
   padding: 0.35rem 0.8rem;
+}
+
+.cloud-preview {
+  margin-top: 1rem;
+  padding: 0.9rem 1.05rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cloud-preview--loading {
+  align-items: center;
+}
+
+.cloud-preview__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cloud-preview__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-slate-800);
+}
+
+.cloud-preview__count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-slate-600);
+}
+
+.cloud-preview__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.cloud-preview__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.cloud-preview__name {
+  font-weight: 600;
+  color: var(--color-slate-800);
+  word-break: break-word;
+  flex: 1 1 auto;
+}
+
+.cloud-preview__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.cloud-preview__badge--new {
+  color: #2563eb;
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.3);
+}
+
+.cloud-preview__badge--existing {
+  color: var(--color-success);
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.cloud-preview__badge--pending {
+  color: #ca8a04;
+  background: rgba(234, 179, 8, 0.15);
+  border-color: rgba(234, 179, 8, 0.32);
+}
+
+.cloud-preview__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-slate-600);
 }
 
 .status-chip {

--- a/src/lib/cloud-link.ts
+++ b/src/lib/cloud-link.ts
@@ -1,0 +1,50 @@
+export class CloudLinkValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CloudLinkValidationError';
+  }
+}
+
+const SUPPORTED_CLOUD_DOMAINS = [
+  'disk.yandex.ru',
+  'yadi.sk',
+  'cloud.mail.ru',
+  'drive.google.com',
+  'docs.google.com',
+  'dropbox.com',
+  'onedrive.live.com',
+  'sharepoint.com',
+  'mega.nz',
+];
+
+export function isSupportedCloudHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return SUPPORTED_CLOUD_DOMAINS.some((domain) => {
+    const target = domain.toLowerCase();
+    return normalized === target || normalized.endsWith(`.${target}`);
+  });
+}
+
+export function normalizeCloudLink(raw: string): string {
+  const value = raw?.trim();
+  if (!value) {
+    throw new CloudLinkValidationError('Ссылка на облачный диск обязательна');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new CloudLinkValidationError('Некорректная ссылка на облачный диск');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new CloudLinkValidationError('Ссылка на облачный диск должна начинаться с http или https');
+  }
+
+  if (!isSupportedCloudHost(parsed.hostname)) {
+    throw new CloudLinkValidationError('Ссылка должна вести на поддерживаемое облачное хранилище');
+  }
+
+  return parsed.toString();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- validate cloud links against supported providers and reuse normalization in report APIs
- add an API endpoint that inspects cloud storage, returning a preview for the UI
- show the scanned files in the upload form with new styles and add unit tests plus vitest alias configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8841c3b448330babd6262e53d402d