### PR TITLE
Fix resolving PDF links in folder cloud listings

### DIFF
--- a/src/lib/cloud-scanner.test.ts
+++ b/src/lib/cloud-scanner.test.ts
@@ -1,43 +1,103 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('./repository', () => ({
-  findReportByCloudLinkAndName: vi.fn(() => null),
+vi.mock('./pdf-parser', () => ({
+  parsePdf: vi.fn(),
 }));
 
-import { inspectCloudStorage } from './cloud-scanner';
-import { findReportByCloudLinkAndName } from './repository';
+vi.mock('./storage', () => ({
+  persistReportFile: vi.fn(),
+  persistReportText: vi.fn(),
+}));
 
-const findReportMock = vi.mocked(findReportByCloudLinkAndName);
+vi.mock('./repository', () => ({
+  createReport: vi.fn(),
+  findReportByCloudLinkAndName: vi.fn(),
+  updateReport: vi.fn(),
+}));
 
-describe('cloud-scanner fetch behaviour', () => {
+import { syncCloudStorage } from './cloud-scanner';
+import { parsePdf } from './pdf-parser';
+import { persistReportFile, persistReportText } from './storage';
+import { createReport, findReportByCloudLinkAndName } from './repository';
+
+describe('cloud-scanner', () => {
   beforeEach(() => {
-    findReportMock.mockReturnValue(null);
+    vi.clearAllMocks();
+    (globalThis as any).fetch = vi.fn();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  it('resolves relative PDF links when the cloud link points to a folder', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch as unknown as ReturnType<typeof vi.fn>);
 
-  it('uses browser-like headers when requesting cloud listings', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch');
-    const html = '<a href="/files/test.pdf">download</a>';
-    const response = new Response(html, {
-      status: 200,
-      headers: { 'content-type': 'text/html' },
-    });
-    fetchMock.mockResolvedValue(response);
+    const htmlResponse = {
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      url: 'https://example.com/folder',
+      text: async () => '<a href="report.pdf">Report</a>',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    };
 
-    await inspectCloudStorage('https://cloud.mail.ru/public/some/path');
+    const pdfResponse = {
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/pdf' }),
+      arrayBuffer: async () => new TextEncoder().encode('pdf-content').buffer,
+    };
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://cloud.mail.ru/public/some/path',
-      expect.objectContaining({ headers: expect.any(Headers) }),
+    fetchMock.mockResolvedValueOnce(htmlResponse as any);
+    fetchMock.mockResolvedValueOnce(pdfResponse as any);
+
+    const parsePdfMock = vi.mocked(parsePdf);
+    parsePdfMock.mockResolvedValue({ text: 'parsed content' });
+
+    const persistReportFileMock = vi.mocked(persistReportFile);
+    persistReportFileMock.mockReturnValue({
+      id: 'report-1',
+      storedName: 'stored-report.pdf',
+      absolutePath: '/tmp/stored-report.pdf',
+    } as any);
+
+    const persistReportTextMock = vi.mocked(persistReportText);
+    persistReportTextMock.mockReturnValue({
+      index: 'report-1.txt',
+      absolutePath: '/tmp/report-1.txt',
+    } as any);
+
+    vi.mocked(createReport).mockReturnValue({
+      id: 'report-1',
+      original_name: 'report.pdf',
+      stored_name: 'stored-report.pdf',
+      text_index: 'report-1.txt',
+      cloud_link: 'https://example.com/folder',
+      added_to_cloud: 1,
+      created_at: new Date().toISOString(),
+    } as any);
+
+    vi.mocked(findReportByCloudLinkAndName).mockReturnValue(undefined);
+
+    const result = await syncCloudStorage('https://example.com/folder');
+
+    expect(result.imported).toBe(1);
+    expect(result.errors).toEqual([]);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/folder',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
     );
 
-    const callOptions = fetchMock.mock.calls[0]?.[1];
-    const headers = callOptions && 'headers' in callOptions ? callOptions.headers : null;
-    expect(headers).toBeInstanceOf(Headers);
-    expect(headers?.get('user-agent')).toContain('Mozilla/5.0');
-    expect(headers?.get('accept')).toContain('text/html');
+    const listingHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers | undefined;
+    expect(listingHeaders).toBeInstanceOf(Headers);
+    expect(listingHeaders?.get('user-agent')).toContain('Mozilla/5.0');
+    expect(listingHeaders?.get('accept')).toContain('text/html');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/folder/report.pdf',
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
   });
 });

--- a/src/lib/cloud-scanner.ts
+++ b/src/lib/cloud-scanner.ts
@@ -49,8 +49,35 @@ function guessFileName(sourceUrl: string): string {
   return 'cloud-file.pdf';
 }
 
+function ensureDirectoryBase(base: string): string {
+  try {
+    const parsed = new URL(base);
+    if (parsed.pathname.endsWith('/')) {
+      return parsed.toString();
+    }
+
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const last = segments.at(-1);
+
+    if (!last) {
+      return parsed.toString();
+    }
+
+    const hasExtension = last.includes('.') || /%2e/i.test(last);
+    if (hasExtension) {
+      return parsed.toString();
+    }
+
+    parsed.pathname = `${parsed.pathname}/`;
+    return parsed.toString();
+  } catch {
+    return base;
+  }
+}
+
 function normaliseUrl(base: string, value: string): string {
-  return new URL(value, base).toString();
+  const normalisedBase = ensureDirectoryBase(base);
+  return new URL(value, normalisedBase).toString();
 }
 
 const BROWSER_FETCH_HEADERS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- ensure cloud folder links are treated as directories when normalising resource URLs
- add a regression test covering folder listings and browser header usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d890666c208330ae05db3322a51cae