### PR TITLE
Sync cloud archive during report listing

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -7,6 +7,19 @@ import { CloudSyncError, syncCloudStorage } from '@/lib/cloud-scanner';
 import { config } from '@/lib/config';
 
 export async function GET() {
+  try {
+    await syncCloudStorage(config.cloudArchiveLink);
+  } catch (error) {
+    if (error instanceof CloudSyncError) {
+      return NextResponse.json({ message: error.message }, { status: 400 });
+    }
+    console.error('Cloud synchronization failed', error);
+    return NextResponse.json(
+      { message: 'Не удалось синхронизировать облачные файлы для сравнения' },
+      { status: 502 }
+    );
+  }
+
   const reports = listReports().map((report) => {
     const latestCheck = findLatestCheckForReport(report.id);
     return {


### PR DESCRIPTION
## Summary
- synchronize the cloud archive before returning the report list so imported files are ready on page load
- return meaningful errors from GET /api/reports when cloud sync fails unexpectedly
- cover the new behavior with unit tests for the listing endpoint and silence error logs in failure cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d89f558b3c8330b2fb9d8c0b6f3f27