### PR TITLE
Track cloud report count independently of uploads

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -57,6 +57,7 @@ describe('GET /api/reports', () => {
   });
 
   it('synchronizes cloud storage before listing reports', async () => {
+    syncCloudStorageMock.mockResolvedValueOnce({ imported: 0, activated: 0, skipped: 1, errors: [] });
     listReportsMock.mockReturnValue([
       {
         id: 'report-1',
@@ -99,6 +100,7 @@ describe('GET /api/reports', () => {
           },
         },
       ],
+      cloudReportsCount: 1,
     });
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,7 @@ interface MatchResult {
 
 export default function HomePage() {
   const [reports, setReports] = useState<ReportListItem[]>([]);
+  const [cloudReportsCount, setCloudReportsCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedCheckId, setSelectedCheckId] = useState<string | null>(null);
@@ -48,7 +49,6 @@ export default function HomePage() {
   const [deleteAllLoading, setDeleteAllLoading] = useState(false);
   const [deletingReportId, setDeletingReportId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const cloudReportsCount = reports.filter((report) => report.addedToCloud).length;
 
   const clearCheckState = () => {
     setSelectedCheckId(null);
@@ -70,6 +70,13 @@ export default function HomePage() {
         addedToCloud: report.addedToCloud ?? false,
       }))
     );
+    if (typeof data.cloudReportsCount === 'number' && Number.isFinite(data.cloudReportsCount)) {
+      setCloudReportsCount(data.cloudReportsCount);
+    } else {
+      setCloudReportsCount(
+        data.reports.filter((report: ReportListItem) => Boolean(report.addedToCloud)).length
+      );
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- return the total number of cloud reports from the reports API using the sync result
- persist the cloud report count in the UI so manual uploads no longer affect the total
- update API tests to cover the new response shape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a70976788330b8b8ac02580bef6f