### PR TITLE
Fix cloud reports counter to reflect synced files

### DIFF
--- a/src/app/api/reports/route.test.ts
+++ b/src/app/api/reports/route.test.ts
@@ -101,6 +101,7 @@ describe('GET /api/reports', () => {
         },
       ],
       cloudReportsCount: 1,
+      cloudSyncErrors: [],
     });
   });
 

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -39,10 +39,12 @@ export async function GET() {
         : null,
     };
   });
-  const cloudReportsCount = cloudSyncResult
-    ? cloudSyncResult.imported + cloudSyncResult.activated + cloudSyncResult.skipped
-    : reports.filter((report) => report.addedToCloud).length;
-  return NextResponse.json({ reports, cloudReportsCount });
+  const cloudReportsCount = reports.filter((report) => report.addedToCloud).length;
+  return NextResponse.json({
+    reports,
+    cloudReportsCount,
+    cloudSyncErrors: cloudSyncResult?.errors ?? [],
+  });
 }
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
## Summary
- compute the cloud reports counter from persisted records instead of sync statistics
- include sync error details in the API response and adjust the existing test expectation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a91ae75c833090b853a7f539dc46