### PR TITLE
Remove diff prefix symbols

### DIFF
--- a/src/app/components/DiffViewer.tsx
+++ b/src/app/components/DiffViewer.tsx
@@ -13,7 +13,6 @@ export function DiffViewer({ segments }: { segments: DiffSegment[] }) {
   return (
     <div className="diff-viewer" aria-live="polite">
       {segments.map((segment, index) => {
-        const prefix = segment.added ? '+' : segment.removed ? '-' : ' ';
         const isMatch = !segment.added && !segment.removed;
         const lineClass = [
           'diff-line',
@@ -26,7 +25,6 @@ export function DiffViewer({ segments }: { segments: DiffSegment[] }) {
           .join(' ');
         return (
           <div key={index} className={lineClass}>
-            <span className="diff-line__prefix">{prefix}</span>
             <pre className="diff-line__content">{segment.value}</pre>
           </div>
         );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -852,9 +852,7 @@ a {
 }
 
 .diff-line {
-  display: grid;
-  grid-template-columns: 28px 1fr;
-  gap: 0.8rem;
+  display: block;
   padding: 0.4rem 0.55rem;
   border-radius: 0.6rem;
   line-height: 1.45;
@@ -875,11 +873,6 @@ a {
 
 .diff-line--context:hover {
   background: rgba(148, 163, 184, 0.15);
-}
-
-.diff-line__prefix {
-  font-weight: 700;
-  color: rgba(226, 232, 240, 0.72);
 }
 
 .diff-line__content {


### PR DESCRIPTION
## Summary
- remove the leading + and - markers from diff rows so matched lines only display underline styling
- simplify the diff row layout styles now that the prefix column is gone

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d8af89744c8330930e0058e99a460d