### PR TITLE
Refine diff viewer match highlighting

### DIFF
--- a/src/app/components/DiffViewer.tsx
+++ b/src/app/components/DiffViewer.tsx
@@ -6,6 +6,33 @@ export interface DiffSegment {
   value: string;
 }
 
+function sanitizeDiffIndicators(value: string) {
+  return value.replace(/^[+-]\s?/gm, '');
+}
+
+function renderMatchValue(value: string) {
+  const lines = value.split('\n');
+  const nodes: (string | JSX.Element)[] = [];
+
+  lines.forEach((line, index) => {
+    if (line.trim().length > 0) {
+      nodes.push(
+        <span key={`match-${index}`} className="diff-line__match-fragment">
+          {line}
+        </span>,
+      );
+    } else if (line.length > 0) {
+      nodes.push(line);
+    }
+
+    if (index < lines.length - 1) {
+      nodes.push('\n');
+    }
+  });
+
+  return nodes.length ? nodes : value;
+}
+
 export function DiffViewer({ segments }: { segments: DiffSegment[] }) {
   if (!segments.length) {
     return <div className="diff-placeholder">Нет данных для сравнения.</div>;
@@ -16,16 +43,18 @@ export function DiffViewer({ segments }: { segments: DiffSegment[] }) {
         const isMatch = !segment.added && !segment.removed;
         const lineClass = [
           'diff-line',
-          segment.added && 'diff-line--added',
-          segment.removed && 'diff-line--removed',
           isMatch && 'diff-line--match',
-          isMatch && 'diff-line--context',
         ]
           .filter(Boolean)
           .join(' ');
+        const value = segment.added || segment.removed
+          ? sanitizeDiffIndicators(segment.value)
+          : segment.value;
         return (
           <div key={index} className={lineClass}>
-            <pre className="diff-line__content">{segment.value}</pre>
+            <pre className="diff-line__content">
+              {isMatch ? renderMatchValue(value) : value}
+            </pre>
           </div>
         );
       })}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -857,22 +857,11 @@ a {
   border-radius: 0.6rem;
   line-height: 1.45;
   transition: background 160ms ease;
+  background: transparent;
 }
 
 .diff-line + .diff-line {
   margin-top: 0.3rem;
-}
-
-.diff-line--added {
-  background: rgba(34, 197, 94, 0.2);
-}
-
-.diff-line--removed {
-  background: rgba(239, 68, 68, 0.22);
-}
-
-.diff-line--context:hover {
-  background: rgba(148, 163, 184, 0.15);
 }
 
 .diff-line__content {
@@ -881,6 +870,10 @@ a {
 }
 
 .diff-line--match .diff-line__content {
+  display: inline;
+}
+
+.diff-line__match-fragment {
   text-decoration-line: underline;
   text-decoration-color: #ef4444;
   text-decoration-thickness: 0.12em;


### PR DESCRIPTION
## Summary
- sanitize diff output so added and removed lines no longer display +/- indicators
- render only matching fragments with underline styling and drop colored diff backgrounds

## Testing
- not run (next lint prompts for interactive config)


------
https://chatgpt.com/codex/tasks/task_e_68d8b161fa648330942d00c54be557f0