### PR TITLE
Highlight shared plagiarism fragments

### DIFF
--- a/src/app/components/DiffViewer.tsx
+++ b/src/app/components/DiffViewer.tsx
@@ -6,58 +6,99 @@ export interface DiffSegment {
   value: string;
 }
 
-function sanitizeDiffIndicators(value: string) {
-  return value.replace(/^[+-]\s?/gm, '');
+interface MatchFragment {
+  id: number;
+  text: string;
+  sourceStart: number;
+  sourceEnd: number;
+  targetStart: number;
+  targetEnd: number;
 }
 
-function renderMatchValue(value: string) {
-  const lines = value.split('\n');
-  const nodes: (string | JSX.Element)[] = [];
+function toLineCount(value: string) {
+  if (!value.length) {
+    return 0;
+  }
+  const normalized = value.replace(/\r/g, '');
+  const parts = normalized.split('\n');
+  if (normalized.endsWith('\n')) {
+    parts.pop();
+  }
+  return parts.length || (normalized.endsWith('\n') ? 1 : 0);
+}
 
-  lines.forEach((line, index) => {
-    if (line.trim().length > 0) {
-      nodes.push(
-        <span key={`match-${index}`} className="diff-line__match-fragment">
-          {line}
-        </span>,
-      );
-    } else if (line.length > 0) {
-      nodes.push(line);
+function normalizeMatchText(value: string) {
+  const cleaned = value.replace(/\r/g, '');
+  const withoutTrailingBreaks = cleaned.replace(/\n+$/g, '');
+  const withoutLeadingBreaks = withoutTrailingBreaks.replace(/^\n+/g, '');
+  return withoutLeadingBreaks.trimEnd();
+}
+
+function buildMatchFragments(segments: DiffSegment[]): MatchFragment[] {
+  const fragments: MatchFragment[] = [];
+  let sourceLine = 1;
+  let targetLine = 1;
+
+  segments.forEach((segment, index) => {
+    const lineCount = toLineCount(segment.value);
+    if (!segment.added && !segment.removed) {
+      const text = normalizeMatchText(segment.value);
+      if (text.length > 0 && lineCount > 0) {
+        fragments.push({
+          id: index,
+          text,
+          sourceStart: sourceLine,
+          sourceEnd: sourceLine + lineCount - 1,
+          targetStart: targetLine,
+          targetEnd: targetLine + lineCount - 1,
+        });
+      }
     }
 
-    if (index < lines.length - 1) {
-      nodes.push('\n');
+    if (!segment.added) {
+      sourceLine += lineCount;
+    }
+    if (!segment.removed) {
+      targetLine += lineCount;
     }
   });
 
-  return nodes.length ? nodes : value;
+  return fragments;
+}
+
+function formatRange(start: number, end: number) {
+  if (start === end) {
+    return `строка ${start}`;
+  }
+  return `строки ${start}–${end}`;
 }
 
 export function DiffViewer({ segments }: { segments: DiffSegment[] }) {
   if (!segments.length) {
     return <div className="diff-placeholder">Нет данных для сравнения.</div>;
   }
+
+  const matches = buildMatchFragments(segments);
+
+  if (!matches.length) {
+    return <div className="diff-placeholder">Общие фрагменты не найдены.</div>;
+  }
+
   return (
-    <div className="diff-viewer" aria-live="polite">
-      {segments.map((segment, index) => {
-        const isMatch = !segment.added && !segment.removed;
-        const lineClass = [
-          'diff-line',
-          isMatch && 'diff-line--match',
-        ]
-          .filter(Boolean)
-          .join(' ');
-        const value = segment.added || segment.removed
-          ? sanitizeDiffIndicators(segment.value)
-          : segment.value;
-        return (
-          <div key={index} className={lineClass}>
-            <pre className="diff-line__content">
-              {isMatch ? renderMatchValue(value) : value}
-            </pre>
-          </div>
-        );
-      })}
+    <div className="match-viewer" aria-live="polite">
+      {matches.map((fragment, index) => (
+        <article key={fragment.id} className="match-fragment">
+          <header className="match-fragment__header">
+            <span className="match-fragment__title">Совпадение #{index + 1}</span>
+            <span className="match-fragment__meta">
+              Отчет: {formatRange(fragment.sourceStart, fragment.sourceEnd)} · Архив: {formatRange(fragment.targetStart, fragment.targetEnd)}
+            </span>
+          </header>
+          <pre className="match-fragment__content">
+            <mark>{fragment.text}</mark>
+          </pre>
+        </article>
+      ))}
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -840,7 +840,7 @@ a {
   text-align: center;
 }
 
-.diff-viewer {
+.match-viewer {
   position: relative;
   border-radius: 1rem;
   background: #0f172a;
@@ -849,35 +849,58 @@ a {
   max-height: 520px;
   overflow: auto;
   box-shadow: 0 25px 48px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.diff-line {
-  display: block;
-  padding: 0.4rem 0.55rem;
-  border-radius: 0.6rem;
-  line-height: 1.45;
-  transition: background 160ms ease;
-  background: transparent;
+.match-fragment {
+  background: rgba(59, 130, 246, 0.08);
+  border-left: 4px solid rgba(59, 130, 246, 0.7);
+  border-radius: 0.8rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
 }
 
-.diff-line + .diff-line {
-  margin-top: 0.3rem;
+.match-fragment__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.diff-line__content {
+@media (min-width: 640px) {
+  .match-fragment__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+}
+
+.match-fragment__title {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.match-fragment__meta {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.match-fragment__content {
   margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
   white-space: pre-wrap;
 }
 
-.diff-line--match .diff-line__content {
-  display: inline;
-}
-
-.diff-line__match-fragment {
-  text-decoration-line: underline;
-  text-decoration-color: #ef4444;
-  text-decoration-thickness: 0.12em;
-  text-decoration-skip-ink: none;
+.match-fragment__content mark {
+  background: rgba(59, 130, 246, 0.22);
+  color: inherit;
+  padding: 0.15rem 0.25rem;
+  border-radius: 0.35rem;
+  box-decoration-break: clone;
 }
 
 .loading-pulse {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -470,7 +470,7 @@ export default function HomePage() {
                 <p className="text-muted">
                   {checkDetails.matches.length}{' '}
                   {pluralize(checkDetails.matches.length, 'совпадение', 'совпадения', 'совпадений')} найдено.
-                  Сравнение проводится с отчетами, добавленными в облако. Выберите файл, чтобы увидеть подробный diff.
+                  Сравнение проводится с отчетами, добавленными в облако. Выберите файл, чтобы увидеть совпавшие фрагменты.
                 </p>
                 <ul className="matches-list">
                   {checkDetails.matches.map((match) => {
@@ -508,7 +508,7 @@ export default function HomePage() {
                   <DiffViewer segments={diff} />
                 ) : (
                   <div className="diff-placeholder">
-                    Выберите совпадение слева, чтобы увидеть детальное сравнение в стиле git diff.
+                    Выберите совпадение слева, чтобы увидеть совпавшие фрагменты двух отчетов.
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- replace the diff-style viewer with a list of shared fragments including line ranges
- add dedicated styling for the match viewer component used in the plagiarism view
- update helper copy to reflect the new matched-fragment presentation instead of git diff wording

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8b404f33c833091bedf180ec902cd