### PR TITLE
Fix type guard for indexed reports

### DIFF
--- a/src/lib/check-processor.ts
+++ b/src/lib/check-processor.ts
@@ -92,7 +92,7 @@ class CheckProcessor {
 
     const indexedReports = getIndexedMatches(reportId)
       .map((id) => getReportById(id))
-      .filter((item): item is ReportRecord => Boolean(item) && item.id !== reportId);
+      .filter((item): item is ReportRecord => item !== undefined && item.id !== reportId);
 
     const matchesFromIndex = evaluateCandidates(indexedReports);
 


### PR DESCRIPTION
## Summary
- ensure the indexed report filter checks for undefined before accessing the id

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d933f3b8088330ba556f0f8bc53104