### PR TITLE
Reset SQLite database before running app or migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "tsx scripts/reset-db.ts",
     "dev": "next dev",
+    "prebuild": "tsx scripts/reset-db.ts",
     "build": "next build",
+    "prestart": "tsx scripts/reset-db.ts",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "premigrate": "tsx scripts/reset-db.ts",
     "migrate": "tsx scripts/migrate-db.ts"
   },
   "dependencies": {

--- a/scripts/reset-db.ts
+++ b/scripts/reset-db.ts
@@ -1,0 +1,33 @@
+import { existsSync, rmSync } from 'fs';
+import { config } from '../src/lib/config';
+
+const databaseFiles = [config.databasePath, `${config.databasePath}-wal`, `${config.databasePath}-shm`];
+
+export const resetDatabase = () => {
+  let removedFiles = 0;
+
+  for (const file of databaseFiles) {
+    if (!file) {
+      continue;
+    }
+
+    if (!existsSync(file)) {
+      continue;
+    }
+
+    rmSync(file);
+    removedFiles += 1;
+  }
+
+  if (removedFiles > 0) {
+    console.log(`Removed ${removedFiles} database file${removedFiles === 1 ? '' : 's'}.`);
+  }
+};
+
+try {
+  resetDatabase();
+} catch (error) {
+  console.error('Failed to reset database before startup.');
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a reusable TypeScript script that removes the SQLite database and related WAL/SHM files
- wire the database reset script into npm lifecycle hooks so dev, build, start, and migrate begin from a clean state

## Testing
- npm run migrate
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9381439148330b80103ffd2630dd1