### PR TITLE
Increase SQLite busy timeout to reduce build locking errors

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { config } from './config';
 
 const db = new Database(config.databasePath);
+db.pragma('busy_timeout = 5000');
 db.pragma('journal_mode = WAL');
 
 const createReportsTable = () => {


### PR DESCRIPTION
## Summary
- add a SQLite busy timeout pragma so concurrent operations wait for locks to clear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d93d066a78833083635016367fef3c