### PR TITLE
Add contextual summary and highlighting for matched report text

### DIFF
--- a/src/app/components/CloudMatchViewer.tsx
+++ b/src/app/components/CloudMatchViewer.tsx
@@ -19,27 +19,53 @@ function renderSegmentContent(value: string) {
 export function CloudMatchViewer({ segments }: { segments: DiffSegment[] }) {
   const visibleSegments = segments.filter((segment) => !segment.removed);
   const hasContent = visibleSegments.some((segment) => segment.value.trim().length > 0);
+  const highlightedFragments = visibleSegments.filter((segment) => !segment.added);
+  const highlightCount = highlightedFragments.reduce(
+    (acc, segment) => (segment.value.trim().length > 0 ? acc + 1 : acc),
+    0
+  );
+  const hasHighlights = highlightCount > 0;
 
   if (!visibleSegments.length || !hasContent) {
     return <div className="diff-placeholder">Нет совпадающих фрагментов в тексте из облака.</div>;
   }
 
   return (
-    <div className="match-viewer" aria-live="polite">
-      {visibleSegments.map((segment, index) => {
-        const isHighlight = !segment.added;
-        const className = [
-          'match-viewer__segment',
-          isHighlight ? 'match-viewer__segment--highlight' : 'match-viewer__segment--context',
-        ]
-          .filter(Boolean)
-          .join(' ');
-        return (
-          <span key={index} className={className}>
-            {renderSegmentContent(segment.value)}
-          </span>
-        );
-      })}
+    <div className="match-viewer-wrapper" aria-live="polite">
+      {hasHighlights && (
+        <p className="match-viewer__meta" role="status">
+          Найдены совпадения в тексте облачного отчета: подчеркнуты {highlightCount}{' '}
+          {pluralizeFragments(highlightCount)}.
+        </p>
+      )}
+      <div className="match-viewer" role="region" aria-label="Текст файла с подчеркнутыми совпадениями">
+        {visibleSegments.map((segment, index) => {
+          const isHighlight = !segment.added;
+          const className = [
+            'match-viewer__segment',
+            isHighlight ? 'match-viewer__segment--highlight' : 'match-viewer__segment--context',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <span key={index} className={className}>
+              {renderSegmentContent(segment.value)}
+            </span>
+          );
+        })}
+      </div>
     </div>
   );
+}
+
+function pluralizeFragments(count: number) {
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  if (mod10 === 1 && mod100 !== 11) {
+    return 'фрагмент';
+  }
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
+    return 'фрагмента';
+  }
+  return 'фрагментов';
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -840,6 +840,18 @@ a {
   text-align: center;
 }
 
+.match-viewer-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-viewer__meta {
+  margin: 0;
+  color: var(--color-slate-500);
+  font-size: 0.95rem;
+}
+
 .match-viewer {
   position: relative;
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- show a status message describing how many fragments were underlined in the matched cloud report
- wrap the match viewer in a dedicated container with ARIA roles so the entire text is displayed with highlighted matches
- extend global styles to support the new wrapper and status message spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d93f3150fc8330b002efd6241c7d3e