### PR TITLE
Switch to diff-match-patch for plagiarism highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "better-sqlite3": "^9.0.0",
-        "diff": "^5.1.0",
+        "diff-match-patch": "^1.0.5",
         "next": "14.1.0",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.6.82",
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/diff": "^5.0.2",
+        "@types/diff-match-patch": "^1.0.36",
         "@types/node": "^20.10.5",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
@@ -1450,10 +1450,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/diff": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
-      "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2843,14 +2843,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^9.0.0",
-    "diff": "^5.1.0",
+    "diff-match-patch": "^1.0.5",
     "next": "14.1.0",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.6.82",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/diff": "^5.0.2",
+    "@types/diff-match-patch": "^1.0.36",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",

--- a/src/app/api/diff/route.ts
+++ b/src/app/api/diff/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { diffLines } from 'diff';
 import { getReportById } from '@/lib/repository';
 import { readReportText } from '@/lib/storage';
+import { buildDiffSegments } from '@/lib/diff-utils';
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
@@ -19,11 +19,7 @@ export async function GET(req: NextRequest) {
   const sourceText = safeReadReportText(source.text_index);
   const targetText = safeReadReportText(target.text_index);
 
-  const diff = diffLines(sourceText, targetText).map((part) => ({
-    added: !!part.added,
-    removed: !!part.removed,
-    value: part.value,
-  }));
+  const diff = buildDiffSegments(sourceText, targetText);
 
   return NextResponse.json({
     source: {

--- a/src/app/components/CloudMatchViewer.tsx
+++ b/src/app/components/CloudMatchViewer.tsx
@@ -1,10 +1,6 @@
 'use client';
 
-export interface DiffSegment {
-  added: boolean;
-  removed: boolean;
-  value: string;
-}
+import type { DiffSegment } from '@/lib/diff-utils';
 
 function renderSegmentContent(value: string) {
   const parts = value.split(/(\n)/);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { CloudMatchViewer, DiffSegment } from './components/CloudMatchViewer';
+import { CloudMatchViewer } from './components/CloudMatchViewer';
+import type { DiffSegment } from '@/lib/diff-utils';
 
 interface ReportListItem {
   id: string;

--- a/src/lib/check-processor.ts
+++ b/src/lib/check-processor.ts
@@ -1,4 +1,4 @@
-import { diffLines } from 'diff';
+import { buildDiffSegments, buildMatchPreview } from './diff-utils';
 import { cosineSimilarity } from './text';
 import { readReportText } from './storage';
 import type { ReportRecord } from './repository';
@@ -73,13 +73,8 @@ class CheckProcessor {
           continue;
         }
         const similarity = cosineSimilarity(reportText, otherText) * 100;
-        const diff = diffLines(otherText, reportText)
-          .map((segment) => {
-            const prefix = segment.added ? '+' : segment.removed ? '-' : ' ';
-            return `${prefix} ${segment.value.trim()}`;
-          })
-          .slice(0, 10)
-          .join('\n');
+        const segments = buildDiffSegments(otherText, reportText);
+        const diff = buildMatchPreview(segments);
         results.push({
           reportId: other.id,
           reportName: other.original_name,

--- a/src/lib/diff-utils.ts
+++ b/src/lib/diff-utils.ts
@@ -1,0 +1,58 @@
+import { diff_match_patch, DIFF_DELETE, DIFF_INSERT } from 'diff-match-patch';
+
+export interface DiffSegment {
+  added: boolean;
+  removed: boolean;
+  value: string;
+}
+
+const MAX_PREVIEW_LENGTH = 180;
+const MAX_PREVIEW_MATCHES = 5;
+
+function createDiffEngine() {
+  const engine = new diff_match_patch();
+  engine.Diff_Timeout = 1;
+  return engine;
+}
+
+export function buildDiffSegments(sourceText: string, targetText: string): DiffSegment[] {
+  const engine = createDiffEngine();
+  const diffs = engine.diff_main(sourceText, targetText);
+  engine.diff_cleanupSemantic(diffs);
+  return diffs.map(([operation, text]) => ({
+    added: operation === DIFF_INSERT,
+    removed: operation === DIFF_DELETE,
+    value: text,
+  }));
+}
+
+export function buildMatchPreview(segments: DiffSegment[]): string {
+  const matches = segments.filter((segment) => !segment.added && !segment.removed);
+  const cleanedMatches = matches
+    .map((segment) => compressWhitespace(segment.value))
+    .filter((value) => value.length > 0);
+  const highlighted = cleanedMatches.slice(0, MAX_PREVIEW_MATCHES).map((value) => `Совпадение: «${truncate(value)}»`);
+  if (highlighted.length > 0) {
+    return highlighted.join('\n');
+  }
+  const fallbackSegments = segments
+    .map((segment) => ({
+      value: compressWhitespace(segment.value),
+      label: segment.added ? 'Добавлено' : segment.removed ? 'Контекст' : 'Совпадение',
+    }))
+    .filter((item) => item.value.length > 0)
+    .slice(0, MAX_PREVIEW_MATCHES)
+    .map((item) => `${item.label}: «${truncate(item.value)}»`);
+  return fallbackSegments.join('\n');
+}
+
+function compressWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string): string {
+  if (value.length <= MAX_PREVIEW_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, MAX_PREVIEW_LENGTH - 1).trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary
- replace the `diff` dependency with `diff-match-patch` to generate semantic segments suitable for highlighting matches
- add shared diff utilities for building API responses and preview snippets of matching fragments
- update the UI components and processing pipeline to use the new segments and show clearer match previews

## Testing
- not run (next lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68d9442936dc83308588f9fbe551ef0d