### PR TITLE
Improve plagiarism scoring with trigram similarity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "plagiarism-inspector",
       "version": "0.1.0",
       "dependencies": {
+        "@types/string-similarity": "^4.0.2",
         "better-sqlite3": "^9.0.0",
         "diff-match-patch": "^1.0.5",
         "next": "14.1.0",
@@ -15,6 +16,7 @@
         "pdfjs-dist": "^4.6.82",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "string-similarity": "^4.0.4",
         "zod": "^3.22.2"
       },
       "devDependencies": {
@@ -1508,6 +1510,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/string-similarity": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/string-similarity/-/string-similarity-4.0.2.tgz",
+      "integrity": "sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
@@ -6458,6 +6466,13 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "migrate": "tsx scripts/migrate-db.ts"
   },
   "dependencies": {
+    "@types/string-similarity": "^4.0.2",
     "better-sqlite3": "^9.0.0",
     "diff-match-patch": "^1.0.5",
     "next": "14.1.0",
@@ -22,6 +23,7 @@
     "pdfjs-dist": "^4.6.82",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "string-similarity": "^4.0.4",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/src/lib/check-processor.ts
+++ b/src/lib/check-processor.ts
@@ -1,5 +1,5 @@
 import { buildDiffSegments, buildMatchPreview } from './diff-utils';
-import { cosineSimilarity } from './text';
+import { plagiarismSimilarity } from './text';
 import { readReportText } from './storage';
 import type { ReportRecord } from './repository';
 import { CheckRecord, createCheck, getCheckById, getReportById, listReports, updateCheck } from './repository';
@@ -72,7 +72,7 @@ class CheckProcessor {
         if (!otherText.trim()) {
           continue;
         }
-        const similarity = cosineSimilarity(reportText, otherText) * 100;
+        const similarity = plagiarismSimilarity(reportText, otherText) * 100;
         const segments = buildDiffSegments(otherText, reportText);
         const diff = buildMatchPreview(segments);
         results.push({

--- a/src/lib/text.test.ts
+++ b/src/lib/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cosineSimilarity, normalizeText, tokenize } from './text';
+import { cosineSimilarity, normalizeText, tokenize, plagiarismSimilarity, trigramSimilarity } from './text';
 
 describe('text helpers', () => {
   it('normalizes whitespace and case', () => {
@@ -17,5 +17,23 @@ describe('text helpers', () => {
 
     expect(cosineSimilarity(a, b)).toBeGreaterThan(0.2);
     expect(cosineSimilarity(a, c)).toBeLessThan(0.1);
+  });
+
+  it('computes trigram similarity that ignores punctuation', () => {
+    const a = 'Архитектура сети SDH: базовые топологии';
+    const b = 'Архитектура сети SDH — базовые топологии';
+    const c = 'Описание другой архитектуры';
+
+    expect(trigramSimilarity(a, b)).toBeGreaterThan(0.8);
+    expect(trigramSimilarity(a, c)).toBeLessThan(0.4);
+  });
+
+  it('combines lexical and structural similarity for plagiarism detection', () => {
+    const reference = 'Архитектура сети SDH включает кольцо, точка-точка и ячеистую топологию.';
+    const suspect = 'Сеть SDH характеризуется топологиями "кольцо", "точка-точка" и "ячеистая".';
+    const unrelated = 'Совершенно не связанный текст о биологии и химии.';
+
+    expect(plagiarismSimilarity(reference, suspect)).toBeGreaterThan(0.55);
+    expect(plagiarismSimilarity(reference, unrelated)).toBeLessThan(0.2);
   });
 });

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,4 +1,7 @@
+import stringSimilarity from 'string-similarity';
+
 const WORD_REGEX = /[\p{L}\p{N}]+/gu;
+const SHINGLE_NORMALIZATION_REGEX = /[^\p{L}\p{N}\s]+/gu;
 
 export function normalizeText(input: string): string {
   return input
@@ -51,4 +54,23 @@ export function cosineSimilarity(textA: string, textB: string): number {
   }
 
   return dotProduct / Math.sqrt(magnitudeA * magnitudeB);
+}
+
+function normalizeForShingles(input: string): string {
+  return normalizeText(input.replace(SHINGLE_NORMALIZATION_REGEX, ''));
+}
+
+export function trigramSimilarity(textA: string, textB: string): number {
+  const normalizedA = normalizeForShingles(textA);
+  const normalizedB = normalizeForShingles(textB);
+  if (!normalizedA || !normalizedB) {
+    return 0;
+  }
+  return stringSimilarity.compareTwoStrings(normalizedA, normalizedB);
+}
+
+export function plagiarismSimilarity(textA: string, textB: string): number {
+  const lexical = cosineSimilarity(textA, textB);
+  const structural = trigramSimilarity(textA, textB);
+  return Math.min(1, lexical * 0.6 + structural * 0.4);
 }


### PR DESCRIPTION
## Summary
- add trigram-based comparison via the string-similarity library
- combine lexical cosine and structural trigram measures for report matching
- expand unit tests to cover the new similarity helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d94944d47483309d4cd1d3bec8c792